### PR TITLE
Add sample .env and update docs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,28 @@
+# Kelly Indexer - Ejemplo de configuración .env
+# Copia este archivo a .env y ajusta los valores según tu entorno.
+
+# --- Configuración de Qdrant ---
+QDRANT_URL=http://localhost:6333
+#QDRANT_API_KEY=tu-clave-api-opcional
+QDRANT_COLLECTION_NAME=kellybot-docs-v1
+DISTANCE_METRIC=Cosine
+
+# --- Modelo de embeddings ---
+EMBEDDING_MODEL_NAME=all-MiniLM-L6-v2
+VECTOR_DIMENSION=384
+
+# --- Rutas de entrada y estado ---
+INPUT_JSON_DIR=./data/input/json/SOAP_TXT
+STATE_FILE_PATH=./scripts/indexer/index_state_qdrant.json
+INPUT_DIR_PROCESSED=./data/input/processed
+OUTPUT_DIR_REPORTS=./data/output/reports
+
+# --- Procesamiento ---
+CHUNK_SIZE=1000
+CHUNK_OVERLAP=150
+QDRANT_BATCH_SIZE=128
+
+# --- Logging ---
+LOG_LEVEL=INFO
+#LOG_FILE=./logs/indexer.log
+

--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,6 @@ logs/
 .env
 # Ignorar también otros archivos .env locales si usas patrones como .env.local, .env.development
 .env.*
-!.env.s# kelly_indexer/.gitignore
 
 # === Archivos de Bytecode y Caché de Python ===
 __pycache__/
@@ -179,4 +178,4 @@ desktop.ini
 .env
 # Ignorar también otros archivos .env locales si usas patrones como .env.local, .env.development
 .env.*
-!.env.sample # Asegurarse de que el ejemplo SÍ esté incluido
+!.env.sample # Incluir ejemplo de configuracion

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ pip install -e .[dev,test]
 
 # Copia y edita configuración
 cp .env.sample .env
+# El archivo `.env.sample` contiene valores de ejemplo.
 nano .env  # Ajusta claves de Qdrant, rutas, modelo, etc.
 ```
 


### PR DESCRIPTION
## Summary
- provide `.env.sample` with the variables required by `config.py`
- adjust `.gitignore` to keep the sample file
- clarify README about the provided sample

## Testing
- `pytest -q -c /dev/null` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68426175313c832fb78dedc8842fec6b