### PR TITLE
Update Qdrant credentials

### DIFF
--- a/.env
+++ b/.env
@@ -2,8 +2,8 @@
 # Copia este archivo a .env y ajusta los valores según tu entorno.
 
 # --- Configuración de Qdrant ---
-QDRANT_URL=https://834a1e10-57dc-4e8d-b968-f69ba404bb31.us-east4-0.gcp.cloud.qdrant.io:6333
-QDRANT_API_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3MiOiJtIn0.IYTF57TdBToBHi2I0aX16u0Hxjs_KRKNMOSGsYSd76c
+QDRANT_URL=https://68a68952-1052-4556-b378-dafb5eeee6e0.europe-west3-0.gcp.cloud.qdrant.io:6333
+QDRANT_API_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3MiOiJtIn0.oavohmPtFJBS8vc9g4-M5qce1lAAtLsm3VLynMLRdhQ
 QDRANT_COLLECTION_NAME=kellybot-docs-v1
 DISTANCE_METRIC=Cosine
 


### PR DESCRIPTION
## Summary
- update Qdrant URL and API key in `.env`

## Testing
- `pytest -q` *(fails: unrecognized arguments because pytest-cov is missing)*
- `python` connection check *(fails: ModuleNotFoundError: No module named 'qdrant_client')*

------
https://chatgpt.com/codex/tasks/task_e_68531d3f0174832f8ce28dc431bc7799